### PR TITLE
[Fix/simplify] A bug fixing from bloom models.

### DIFF
--- a/python/welder/schedule/schedule.py
+++ b/python/welder/schedule/schedule.py
@@ -5,6 +5,7 @@ from tvm import te
 from ..config import Config, Stride
 from ..te_utils import get_compute_ops, seperate_reduce_ops
 from .tir_elementwise import *
+from .te_elementwise import *
 from .te_reduce import *
 from .te_reduce_interthread import *
 from .te_wmma import *
@@ -16,7 +17,12 @@ def schedule(args: List[te.Tensor], config: Config, shared_inputs: List[te.Tenso
         shared_inputs_strides: Dict[te.Tensor, Stride] = {}, shared_outputs = []):
     ops = get_compute_ops(args)
     reduces_ops, _ = seperate_reduce_ops(ops)
-
+    input_args, output_args = [], []
+    for arg in args:
+        if isinstance(arg.op, te.PlaceholderOp):
+            input_args.append(arg)
+        else:
+            output_args.append(arg)
     schedule_on_inner_stage = False
     for tensor in args:
         if isinstance(tensor.op, te.ComputeOp) and tensor.name not in config.schedule_stages:
@@ -24,7 +30,10 @@ def schedule(args: List[te.Tensor], config: Config, shared_inputs: List[te.Tenso
 
     if len(reduces_ops) == 0:
         assert(not schedule_on_inner_stage)
-        template = TIRElementWiseScheduler
+        if len(output_args) > 1:
+            template = TEElementWiseScheduler
+        else:
+            template = TIRElementWiseScheduler
     elif config.use_tc and config.use_cutlass:
         template = TIRCutlassMMAScheduler
     elif config.use_tc and not config.use_cutlass:

--- a/python/welder/schedule/schedule.py
+++ b/python/welder/schedule/schedule.py
@@ -4,7 +4,7 @@ from tvm import te
 
 from ..config import Config, Stride
 from ..te_utils import get_compute_ops, seperate_reduce_ops
-from .te_elementwise import *
+from .tir_elementwise import *
 from .te_reduce import *
 from .te_reduce_interthread import *
 from .te_wmma import *
@@ -24,7 +24,7 @@ def schedule(args: List[te.Tensor], config: Config, shared_inputs: List[te.Tenso
 
     if len(reduces_ops) == 0:
         assert(not schedule_on_inner_stage)
-        template = TEElementWiseScheduler
+        template = TIRElementWiseScheduler
     elif config.use_tc and config.use_cutlass:
         template = TIRCutlassMMAScheduler
     elif config.use_tc and not config.use_cutlass:

--- a/python/welder/schedule/tir_base.py
+++ b/python/welder/schedule/tir_base.py
@@ -7,13 +7,14 @@ from tvm import te, tir
 from ..config import Stride
 from ..IRpass import *
 from .scheduler_base import SchedulerBase
+from tvm.tir.transform import Simplify
 
 
 class TIRSchedulerBase(SchedulerBase):
     def create_schedule(self) -> tir.Schedule:
         workload = te.create_prim_func(self.args)
         ir_module = tvm.IRModule({"main": workload})
-        return tir.Schedule(ir_module)
+        return tir.Schedule(Simplify()(ir_module))
 
     def debug_schedule(self):
         print(self.sche.mod["main"].script())

--- a/python/welder/schedule/tir_elementwise.py
+++ b/python/welder/schedule/tir_elementwise.py
@@ -1,0 +1,69 @@
+import numpy as np
+from tvm import tir
+import tvm
+import os
+from ..config import Stride
+from .tir_base import TIRSchedulerBase
+
+
+class TIRElementWiseScheduler(TIRSchedulerBase):
+    def schedule(self) -> tir.Schedule:
+        
+        sch, config = self.sche, self.config
+        self.schedule_compute_inline()
+        self.block_size[0] = int(np.prod(config.thread))
+
+        C = sch.get_block(self.output_op.name)
+        space_loops = sch.get_loops(C)[:len(self.output_op.axis)]        
+
+        blck_axis = []
+        vthd_axis = []
+        thrd_axis = []
+        tile_axis = []
+        for i, loop in enumerate(space_loops):
+            if self.output_op.axis[i].dom.extent % config.block[i]:
+                raise NotImplementedError("Undivisible block in TIR schedule is still buggy.")
+            bx, _t = sch.split(loop, factors=[None, config.block[i]])
+            vx, _t = sch.split(
+                _t, factors=[None, config.thread[i] * config.step[i]])
+            tx, tn = sch.split(_t, factors=[None, config.step[i]])
+            blck_axis.append(bx)
+            vthd_axis.append(vx)
+            thrd_axis.append(tx)
+            tile_axis.append(tn)
+        vthd_axis = list(reversed(vthd_axis))  # inner virtual thread first
+        axis_order = blck_axis + vthd_axis + thrd_axis + tile_axis
+        sch.reorder(*axis_order)
+        blck_fused = sch.fuse(*blck_axis)
+        thrd_fused = sch.fuse(*thrd_axis)
+        sch.bind(blck_fused, "blockIdx.x")
+        sch.bind(thrd_fused, "threadIdx.x")
+        if len(vthd_axis) > 3:
+            vthd_axis = vthd_axis[0:2] + [sch.fuse(*vthd_axis[2:])]
+        for i, ax in enumerate(vthd_axis):
+            sch.bind(ax, "vthread" + ['.x', '.y', '.z'][i])
+        for ax in tile_axis:
+            sch.unroll(ax)
+
+        # ----- cache small tensors -----
+        cached_stages = []
+        for i, input_tensor in enumerate(self.output_op.input_tensors):
+            cached_stages.append(input_tensor.name)
+
+        cache_plan = self.make_cache_plan()
+
+        for tensor in cache_plan:
+            tensor_shared = sch.cache_read(C, tensor.name, "shared")
+            sch.compute_at(tensor_shared, thrd_fused)
+            if tensor in self.shared_inputs_strides:
+                strides = self.shared_inputs_strides[tensor]
+            else:
+                strides = Stride()
+            dim_offset = len(vthd_axis) + 2 # outer loops are: blck_fused vthd_axis thrd_fused
+            self.cooperative_fetch(tensor_shared, dim_offset, strides)
+            if len(self.shared_outputs) == 0:
+                continue
+            tensor_local = sch.cache_read(C, tensor.name, "local")
+            sch.compute_at(tensor_local, thrd_fused)
+
+        return sch.mod["main"]


### PR DESCRIPTION
When leveraged welder_relay with bloom model, we found that groups end up with reshape can not generate right schedule with elem-wise template, that was caused by the complex expression around multiple reshapes and transformations.

```python
@T.prim_func
def func(p0: T.Buffer[(8192, 43008), "float16"], p1: T.Buffer[43008, "float16"], T_reshape_4: T.Buffer[(16, 512, 112, 3, 128), "float16"]):
    # function attr dict
    T.func_attr({"global_symbol": "main", "tir.noalias": True})
    # body
    # with T.block("root")
    for ax0, ax1, ax2, ax3, ax4 in T.grid(16, 512, 112, 3, 128):
        with T.block("T_reshape_4"):
            v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
            T.reads(p0[((v_ax1 * 43008 + v_ax2 * 384 + v_ax3 * 128 + v_ax4) // 22020096 + v_ax0) % 16 * 512 + ((v_ax2 * 384 + v_ax3 * 128 + v_ax4) // 43008 + v_ax1) % 512, (v_ax2 * 384 + v_ax3 * 128 + v_ax4) % 43008], p1[(v_ax2 * 384 + v_ax3 * 128 + v_ax4) % 43008])
            T.writes(T_reshape_4[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
            T_reshape_4[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = p0[(((v_ax1 * 43008 + v_ax2 * 384 + v_ax3 * 128 + v_ax4) // 22020096 + v_ax0) % 16 * 512 + (v_ax2 * 384 + v_ax3 * 128 + v_ax4) % 43008 // 43008 + ((v_ax2 * 384 + v_ax3 * 128 + v_ax4) // 43008 + v_ax1) % 512) % 8192, (v_ax2 * 384 + v_ax3 * 128 + v_ax4) % 43008 % 43008] + p1[(v_ax2 * 384 + v_ax3 * 128 + v_ax4) % 43008]
```

which is supposed to be:

```python
# from tvm.script import tir as T
@T.prim_func
def func(p0: T.Buffer[(8192, 43008), "float16"], p1: T.Buffer[43008, "float16"], T_reshape_4: T.Buffer[(16, 512, 112, 3, 128), "float16"]):
    # function attr dict
    T.func_attr({"global_symbol": "main", "tir.noalias": True})
    # body
    # with T.block("root")
    for ax0, ax1, ax2, ax3, ax4 in T.grid(16, 512, 112, 3, 128):
        with T.block("T_reshape_4"):
            v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
            T.reads(p0[v_ax0 * 512 + v_ax1, v_ax2 * 384 + v_ax3 * 128 + v_ax4], p1[v_ax2 * 384 + v_ax3 * 128 + v_ax4])
            T.writes(T_reshape_4[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
            T_reshape_4[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = p0[v_ax0 * 512 + v_ax1, v_ax2 * 384 + v_ax3 * 128 + v_ax4] + p1[v_ax2 * 384 + v_ax3 * 128 + v_ax4]

```

to reproduce this situation, please checkout:


```python
import numpy as np
import tvm
import welder
from tvm import relay
import os.path as osp
from tvm.contrib.target.onnx import to_onnx
from tvm.relay.testing import run_infer_type
from tvm.contrib import graph_executor
from utils.logger import write_mod
import os
import logging
welder.set_log_level(logging.DEBUG)
# get file name and remove the suffix
fname = os.path.basename(__file__)
fname = os.path.splitext(fname)[0]
# create log path
log_path = "progress/" + fname

arch = "cuda"
arch = welder.arch.__getattribute__(arch)()
dtype = "float16"
'''
%80 = fn (%p017: Tensor[(8192, 43008), float16] /* ty=Tensor[(8192, 43008), float16] */, %p116: Tensor[(43008), float16] /* ty=Tensor[(43008), float16] */) -> Tensor[(16, 512, 112, 3, 128), float16] {
    %38 = reshape(%p017, newshape=[16, 512, 43008]) /* ty=Tensor[(16, 512, 43008), float16] */;
    %39 = add(%p116, %38) /* ty=Tensor[(16, 512, 43008), float16] */;
    reshape(%39, newshape=[16, 512, 112, 3, 128]) /* ty=Tensor[(16, 512, 112, 3, 128), float16] */
  } /* ty=fn (Tensor[(8192, 43008), float16], Tensor[(43008), float16]) -> Tensor[(16, 512, 112, 3, 128), float16] */;
'''
input_shape = (8192, 43008)
bias_shape = (43008,)
A = relay.var("data", shape=input_shape, dtype=dtype)
Bias = relay.var("bias", shape=bias_shape, dtype=dtype)
_reshape = relay.reshape(A, newshape=[16, 512, 43008])
_reshape_add = relay.add(_reshape, Bias)
_reshape_add_bias = relay.reshape(
    _reshape_add, newshape=[16, 512, 112, 3, 128])

f = relay.Function([A, Bias], _reshape_add_bias)
mod = tvm.IRModule.from_expr(f)
write_mod(mod, log_path, "create_mod")
# must convert bias_add -> broadcast_add to propogate the layout
mod = relay.transform.InferType()(mod)
# mod = relay.transform.CanonicalizeOps()(mod)
write_mod(mod, log_path, "CanonicalizeOps")
mod = relay.transform.ConvertLayout({"nn.conv2d": ["NHWC", "HWIO"]})(mod)
write_mod(mod, log_path, "ConvertLayout")
mod = relay.transform.FoldConstant()(mod)
write_mod(mod, log_path, "layout_transform")
mod = welder.relay.transform.WelderExprRewrite()(mod)
write_mod(mod, log_path, "expr_rewrite")
mod = welder.relay.transform.WelderDotSplitK()(mod)
write_mod(mod, log_path, "WelderDotSplitK")
write_mod(mod, log_path, "FoldConstant")
mod = welder.relay.transform.WelderFuseOps()(mod)
write_mod(mod, log_path, "WelderFuseOps")
mod = welder.relay.transform.AnnotateTensorCore()(mod)
write_mod(mod, log_path, "AnnotateTensorCore")
mod = welder.relay.transform.WelderTunePass(arch, topk=1)(mod)
write_mod(mod, log_path, "WelderTunePass")
factory = relay.build(mod, arch.target)

lib = welder.relay.update_lib(
    factory.get_lib(), arch, osp.join(log_path, "model.so"))
with open(osp.join(log_path, "graph.json"), "w") as f:
    f.write(factory.get_graph_json())
with open(osp.join(log_path, "graph.params"), "wb") as f_params:
    f_params.write(tvm.runtime.save_param_dict(factory.get_params()))
rt_mod = graph_executor.create(factory.get_graph_json(), lib, tvm.cuda(0))
rt_mod.set_input(**factory.get_params())
print(rt_mod.benchmark(tvm.cuda(0), min_repeat_ms=500, end_to_end=False))

```
  